### PR TITLE
Fix aria-current

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -7,14 +7,16 @@ return [
             $children = [];
 
             if ($child->children()->isNotEmpty()) {
-                array_push($children, $child->children()->toNavigationMenu($field));
+                array_push($children, $child->children());
             }
+
             array_push($items, [
                 'id' => $child->id(),
                 'url' => $child->url()->value(),
                 'text' => $child->text()->value(),
                 'title' => $child->title()->value(),
                 'popup' => $child->popup()->toBool(),
+                'isOpen' => kirby()->url('current') === $child->url()->value(),
                 'children' => $children,
             ]);
         }

--- a/snippets/navigation.php
+++ b/snippets/navigation.php
@@ -7,7 +7,7 @@
             <a href="<?php echo $child->url(); ?>"
                title="<?php echo $child->title()->html() ?>"
                target="<?php e($child->popup()->toBool(), '_blank', '_self') ?>"
-               <?php e($child->isOpen(), ' aria-current') ?>
+               <?php e($child->url()->value() === kirby()->url('current'), ' aria-current') ?>
             >
                 <?php echo $child->text()->html() ?>
             </a>


### PR DESCRIPTION
Since we don't use pages as object, I have to use `kirby()->url('current') === $child->url()->value()` to get current page is open.

- Fixes #18 