### PR TITLE
Added field context in yaml + fixed nav output

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,15 @@ Copy plugin files to your plugin's directory. Use the following blueprint anywhe
 Add the following blueprint to wherever you would like the navigation field to appear.
 
 ```yaml
-navigation:
-  label: Navigation
-  type: navigation
-  levels: 5
-  help: Description of menu or where it is used
-  width: 1/2
+fields:
+  type: fields
+  fields:
+    navigation:
+      label: Navigation
+      type: navigation
+      levels: 5
+      help: Description of menu or where it is used
+      width: 1/2
 ```
 
 Two Field methods are included which will output the menu regardless of how many levels deep you go:
@@ -69,7 +72,7 @@ If you would like full control of your menu and would prefer to use a foreach to
             <ul>
               <?php foreach($nav->children()->toStructure() as $child): ?>
                 <a href="<?php echo $child->url() ?>">
-                  <?php echo $nav->text() ?>
+                  <?php echo $child->text() ?>
                 </a>
               <?php endforeach ?>
             </ul>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Add the following blueprint to wherever you would like the navigation field to a
 
 ```yaml
 fields:
-  type: fields
   fields:
     navigation:
       label: Navigation

--- a/README.md
+++ b/README.md
@@ -24,13 +24,12 @@ Add the following blueprint to wherever you would like the navigation field to a
 
 ```yaml
 fields:
-  fields:
-    navigation:
-      label: Navigation
-      type: navigation
-      levels: 5
-      help: Description of menu or where it is used
-      width: 1/2
+  navigation:
+    label: Navigation
+    type: navigation
+    levels: 5
+    help: Description of menu or where it is used
+    width: 1/2
 ```
 
 Two Field methods are included which will output the menu regardless of how many levels deep you go:

--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ If you would like full control of your menu and would prefer to use a foreach to
           <?php if($nav->children()->isNotEmpty()): ?>
             <ul>
               <?php foreach($nav->children()->toStructure() as $child): ?>
-                <a href="<?php echo $child->url() ?>">
-                  <?php echo $child->text() ?>
-                </a>
+                <li>
+                  <a href="<?php echo $child->url() ?>">
+                    <?php echo $child->text() ?>
+                  </a>
+                </li>
               <?php endforeach ?>
             </ul>
           <?php endif ?>


### PR DESCRIPTION
Added field context in yaml example, maybe only useful for newcomers? I've found that at least one person had the same need for clarity there https://forum.getkirby.com/t/setup-navigation-field-plugin/25317

Fixed the example for the nav full output, the parent text was used instead of the child one.