### PR TITLE
Update version to 5.0.11 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "menu",
     "field"
   ],
-  "version": "5.0.8",
+  "version": "5.0.11",
   "license": "MIT",
   "homepage": "https://github.com/chrisbeluga/kirby-navigation",
   "authors": [


### PR DESCRIPTION
Hi,
If you install the plugin via Composer, it remains at version 5.0.8 (you can see this on Packagist.org: https://packagist.org/packages/belugadigital/kirby-navigation)

Best regards